### PR TITLE
Setup Continuous Integration for repository

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,29 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test


### PR DESCRIPTION
## Goal

This changeset adds [Continuous Integration](https://www.thoughtworks.com/continuous-integration) (CI) to the repository. This means that whenever code is pushed in a pull request Github's servers will check out the code, build it, and run the unit tests.

Continuous Integration is a really helpful way of automatically finding out if a file hasn't been added to version control, or if tests have been broken by changes made in a pull request.

This PR uses [Github Actions](https://docs.github.com/en/actions/building-and-testing-code-with-continuous-integration/setting-up-continuous-integration-using-github-actions) to checkout and test the code. If the tests fail for a pull request, this will show up as a [status check](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) in the form of a red cross.